### PR TITLE
Info about recently departed faculty

### DIFF
--- a/RecLetters/RecLetters.tex
+++ b/RecLetters/RecLetters.tex
@@ -197,24 +197,24 @@ who are not JHU faculty, including recently departed JHU faculty who still have 
 \end{itemize}
 
 \item {\bf \AJO ~ (\AJOLink):}
-Students will enter Maggie's name, with the email address \JMStaffEmail, on the cover sheet provided by the AJO system. Check the box: ``must check here if the person above will upload letters on behalf of multiple writers'' and enter the actual writers' names in the box provided. After all reference letters for each student are received, Maggie will make 1 PDF file of all letters and upload their file to the AJO site. The student will be allowed to see when this upload is complete. This service will be provided for both JHU Economics and external recommenders.
+Students will enter Kasey's name, with the email address \JMStaffEmail, on the cover sheet provided by the AJO system. Check the box: ``must check here if the person above will upload letters on behalf of multiple writers'' and enter the actual writers' names in the box provided. After all reference letters for each student are received, Kasey will make 1 PDF file of all letters and upload their file to the AJO site. The student will be allowed to see when this upload is complete. This service will be provided for both JHU Economics and external recommenders.
 
 \item {\bf \AEA ~ (\AEALink):}
-Students who are using \AEA~must ask their JHU Economics Department reference writer to go to \AEARecLink~ and set up a surrogate for their reference letters. The surrogate name is Maggie Potts and the email address is \JMStaffEmail. This service will be provided for JHU Economic professors only. Recommenders who are not Department of Economics full-time faculty must upload their letters themselves, including recently departed JHU faculty who still have an official JHU email (the letter writer must write from their new institution).
+Students who are using \AEA~must ask their JHU Economics Department reference writer to go to \AEARecLink~ and set up a surrogate for their reference letters. The surrogate name is Kasey Bocek and the email address is \JMStaffEmail. This service will be provided for JHU Economic professors only. Recommenders who are not Department of Economics full-time faculty must upload their letters themselves, including recently departed JHU faculty who still have an official JHU email (the letter writer must write from their new institution).
 
 
 \item {\bf \Interfolio ~ (\InterfolioLink):}
-Before students start to use the Interfolio System, Maggie must first let students know the type of reference letters that were written by each of their professors for them. For example: Generic, Academic, or Non-Academic. Students need to specify which letter they want uploaded to each application they submit. In other words, students must select a professor and a type of letter the professor has written, each time they submit an application on the Interfolio system.
+Before students start to use the Interfolio System, Kasey must first let students know the type of reference letters that were written by each of their professors for them. For example: Generic, Academic, or Non-Academic. Students need to specify which letter they want uploaded to each application they submit. In other words, students must select a professor and a type of letter the professor has written, each time they submit an application on the Interfolio system.
 
 When entering the recommendation requests in Interfolio please make sure to:
 \begin{itemize}
 \item Enter the name of your recommender and econ@jhu.edu as the recommender's e-mail.
-\item For each recommendation request, specify under ``Document Title'' the recommender's name and the type of the recommendation letter (generic, academic, non-academic. etc.) per Maggie's e-mail.
-For example, if Maggie emailed you that Professor Ball wrote you both academic and non-academic letters of recommendation, one of your document titles would be: \texttt{Dr. Laurence Ball\_non-academic recommendation} and another would be \texttt{Dr. Laurence Ball\_academic recommendation}.
+\item For each recommendation request, specify under ``Document Title'' the recommender's name and the type of the recommendation letter (generic, academic, non-academic. etc.) per Kasey's e-mail.
+For example, if Kasey emailed you that Professor Ball wrote you both academic and non-academic letters of recommendation, one of your document titles would be: \texttt{Dr. Laurence Ball\_non-academic recommendation} and another would be \texttt{Dr. Laurence Ball\_academic recommendation}.
 \item Under ``Recommendation Destination'' there are two choices: General and Specific position. Only choose ``Specific position'' and enter the recommender name along with the type of the reference letter.
 \end{itemize}
 
-All Interfolio reference letters will be uploaded to Interfolio directly by Maggie, including the ones from external recommenders.
+All Interfolio reference letters will be uploaded to Interfolio directly by Kasey, including the ones from external recommenders.
 
 \item {\bf Pull email}: Some employers have set up systems that allow
   recommenders to upload letters directly themselves.  These employers
@@ -321,9 +321,9 @@ In sum, both inside and outside recommenders send their letters to \JMStaffEmail
 
 \begin{quote}
 \begin{itemize}
-\item[EJM] New inside recommenders should set \JMStaffEmail~as their proxy (old inside recommenders should already have done this in prior years, and need to do nothing at all beyond sending letters to \JMStaffEmail). Maggie can only proxy JHU Economics Faculty letters. \textcolor{red}{Recommenders who are not Department of Economics full-time faculty must upload their letters themselves.}
-\textcolor{red}{\item[AJO] New inside recommenders should set \JMStaffEmail~as their proxy (old inside recommenders should already have done this in prior years, and need to do nothing at all beyond sending letters to \JMStaffEmail). Maggie can only proxy JHU Economics Faculty letters.} \textcolor{red}{Recommenders who are not Department of Economics full-time faculty must upload their letters themselves.}
-\textcolor{red}{\item[AEA/JOE] All inside recommenders should set \JMStaffEmail~as their proxy. The faculty need to set Maggie Potts as their proxy each year, as this system does not carry their proxies over from year to year. Maggie can only proxy JHU Economics Faculty letters.} \textcolor{red}{Recommenders who are not Department of Economics full-time faculty must upload their letters themselves.}
+\item[EJM] New inside recommenders should set \JMStaffEmail~as their proxy (old inside recommenders should already have done this in prior years, and need to do nothing at all beyond sending letters to \JMStaffEmail). Kasey can only proxy JHU Economics Faculty letters. \textcolor{red}{Recommenders who are not Department of Economics full-time faculty must upload their letters themselves.}
+\textcolor{red}{\item[AJO] New inside recommenders should set \JMStaffEmail~as their proxy (old inside recommenders should already have done this in prior years, and need to do nothing at all beyond sending letters to \JMStaffEmail). Kasey can only proxy JHU Economics Faculty letters.} \textcolor{red}{Recommenders who are not Department of Economics full-time faculty must upload their letters themselves.}
+\textcolor{red}{\item[AEA/JOE] All inside recommenders should set \JMStaffEmail~as their proxy. The faculty need to set Kasey Bocek as their proxy each year, as this system does not carry their proxies over from year to year. Kasey can only proxy JHU Economics Faculty letters.} \textcolor{red}{Recommenders who are not Department of Economics full-time faculty must upload their letters themselves.}
 \textcolor{red}{\item[Interfolio]  Inside and outside recommenders follow the same procedures, which require the student to send carefully-constructed emails to \JMStaffEmail~as described above.}
 \item[Push Email]  Inside and outside recommenders follow the same procedures, which require the student to send carefully-constructed emails to \JMStaffEmail~as described above.
 \item[Pull Email]  For inside recommenders, student requests employer send email to \JMStaffEmail.  For outside recommenders, student requests employer send email to recommender's outside email address.
@@ -380,7 +380,7 @@ with a centralized way of keeping track of where the process is.  To
 repeat, you must NOT upload your letters yourself; you MUST designate
 a proxy.
 
-The proxy is Maggie Potts; the email address to use for the proxy is
+The proxy is Kasey Bocek; the email address to use for the proxy is
 \JMStaffEmail.  The good thing about using a proxy is that you (as a faculty member)
 need only to send your letters out once, to \JMStaffEmail, and everything 
 else is handled for you after that.  
@@ -388,12 +388,12 @@ else is handled for you after that.
 \begin{comment}
 \textcolor{red}{
 \item {\bf \AJO:}
-Each JHU faculty member must register at \AJOLink~ and enter Maggie Potts as their proxy, using the
+Each JHU faculty member must register at \AJOLink~ and enter Kasey Bocek as their proxy, using the
 \JMStaffEmail~ email address. To do this, log in to your account and click on the `proxy' link near the bottom. This only needs to be done once and the proxy works for all applicants the faculty may have on the job market that year.}
 \end{comment}
 
 \item {\bf \AEA:}
-Each faculty member must register at \AEARecLink. After you create an account, you will have to designate Maggie as a surrogate to manage your reference letters. The surrogate name is Maggie Potts and the email address is \JMStaffEmail. The faculty need to set Maggie Potts as their proxy each year, as this system does not carry their proxies over from year to year.
+Each faculty member must register at \AEARecLink. After you create an account, you will have to designate Kasey as a surrogate to manage your reference letters. The surrogate name is Kasey Bocek and the email address is \JMStaffEmail. The faculty need to set Kasey Bocek as their proxy each year, as this system does not carry their proxies over from year to year.
 
 \end{enumerate}
 

--- a/RecLetters/RecLetters.tex
+++ b/RecLetters/RecLetters.tex
@@ -191,7 +191,7 @@ login ID at \EJM~will need to have an account created for them (the account is c
     \texttt{colleen.carey@jhu.edu}, and then they select all employers and tick the box for all
     future employers.}
 New \EJM~security measures prevent us from uploading letters on behalf of people
-who are not JHU faculty.  The student must communicate this information to
+who are not JHU faculty, including recently departed JHU faculty who still have an official JHU email (the letter writer must write from their new institution).  The student must communicate this information to
   the recommender.
 
 \end{itemize}
@@ -200,7 +200,7 @@ who are not JHU faculty.  The student must communicate this information to
 Students will enter Maggie's name, with the email address \JMStaffEmail, on the cover sheet provided by the AJO system. Check the box: ``must check here if the person above will upload letters on behalf of multiple writers'' and enter the actual writers' names in the box provided. After all reference letters for each student are received, Maggie will make 1 PDF file of all letters and upload their file to the AJO site. The student will be allowed to see when this upload is complete. This service will be provided for both JHU Economics and external recommenders.
 
 \item {\bf \AEA ~ (\AEALink):}
-Students who are using \AEA~must ask their JHU Economics Department reference writer to go to \AEARecLink~ and set up a surrogate for their reference letters. The surrogate name is Maggie Potts and the email address is \JMStaffEmail. This service will be provided for JHU Economic professors only. Recommenders who are not Department of Economics full-time faculty must upload their letters themselves.
+Students who are using \AEA~must ask their JHU Economics Department reference writer to go to \AEARecLink~ and set up a surrogate for their reference letters. The surrogate name is Maggie Potts and the email address is \JMStaffEmail. This service will be provided for JHU Economic professors only. Recommenders who are not Department of Economics full-time faculty must upload their letters themselves, including recently departed JHU faculty who still have an official JHU email (the letter writer must write from their new institution).
 
 
 \item {\bf \Interfolio ~ (\InterfolioLink):}


### PR DESCRIPTION
Updated to say that recently departed faculty, even if they still have a jhu email, must be treated as non-jhu.