### PR TITLE
Correct typo jmstaff email

### DIFF
--- a/JobMarketProceduresHelp.md
+++ b/JobMarketProceduresHelp.md
@@ -89,7 +89,7 @@ Below is information about each of the main methods for causing your recommendat
 
 ### General Procedure
 
-Information can be found at [RecLetters](https://github.com/llorracc/JobMarket/RecLetters/). This service will be provided for JHU Economics professors and any outside reference letter writers who are willing to name [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) as their proxy to upload letters.
+Information can be found at [RecLetters](https://github.com/llorracc/JobMarket/RecLetters/). This service will be provided for JHU Economics professors and any outside reference letter writers who are willing to name [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) as their proxy to upload letters.
 
 ### Multiple Letters
 
@@ -101,9 +101,9 @@ We handle this problem using two alternative procedures:
 
 ##### Semi-Auto Solution:
 
-We will upload a main/generic reference which will be automatically submitted to all employers/schools. We then withdraw this reference from the non-academic institutions. You are responsible for letting [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) know which non-academic institutions you have applied to, so that the wrong reference is withdrawn and replaced with the correct one[\[1\]](http://www.econ2.jhu.edu/jobmarket/Information/JobMarketProceduresHelp.html#footnote-1).
+We will upload a main/generic reference which will be automatically submitted to all employers/schools. We then withdraw this reference from the non-academic institutions. You are responsible for letting [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) know which non-academic institutions you have applied to, so that the wrong reference is withdrawn and replaced with the correct one[\[1\]](http://www.econ2.jhu.edu/jobmarket/Information/JobMarketProceduresHelp.html#footnote-1).
 
-If you only have one generic letter from a faculty member, that is the letter that will be uploaded and sent out automatically. If you need another type of reference letter (non-academic, research, teaching) sent out, you are responsible for letting [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) know which type of letter needs to uploaded to what site and to which places you are applying. You will convey this type of information on each spreadsheet that will be emailed to [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation).
+If you only have one generic letter from a faculty member, that is the letter that will be uploaded and sent out automatically. If you need another type of reference letter (non-academic, research, teaching) sent out, you are responsible for letting [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) know which type of letter needs to uploaded to what site and to which places you are applying. You will convey this type of information on each spreadsheet that will be emailed to [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation).
 
 ##### Manual Solution:
 
@@ -125,37 +125,37 @@ For staff:
 Instructions for using Interfolio for letters of recommendation:
 
 1.  Indicate that you are going to use Interfolio in your spreadsheets (AppSubmitMethod, RecLetterSendGroup).
-2.  Wait for an email from [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) indicating that she has received ALL your letters of recommendation. [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) will tell you if you have multiple letters of recommendation from a specific faculty member as well as the type of recommendation (E.g. generic, academic, non-academic, etc...). **DO NOT PROCEED** with the recommendation requests if you don't know the type of recommendation letter you are getting from each specific faculty member.
+2.  Wait for an email from [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) indicating that she has received ALL your letters of recommendation. [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) will tell you if you have multiple letters of recommendation from a specific faculty member as well as the type of recommendation (E.g. generic, academic, non-academic, etc...). **DO NOT PROCEED** with the recommendation requests if you don't know the type of recommendation letter you are getting from each specific faculty member.
 3.  When entering the recommendation requests in Interfolio please make sure to:
 a. Start the recommendation request by going to "Letters" in the left menu bar.
-b. Enter the name of your recommender as [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) \JMStaffNameLast and econ@jhu.edu as her e-mail for each recommendation request. You need to do this as many times as the number of recommendation letters you are expecting to have.
-c. For each recommendation request, specify under "Document Title" the recommender’s actual name (e.g. Dr. Laurence Ball) and the type of the recommendation letter (generic, academic, non-academic. etc.) per [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation)'s e-mail.
-_For example, if [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) emailed you that Professor Ball wrote you both academic and non-academic letters of recommendation, one of your document titles would be: **Dr. Laurence Ball\_non-academic recommendation** and another would be **Dr. Laurence Ball\_academic recommendation.**_
+b. Enter the name of your recommender as [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) \JMStaffNameLast and econ@jhu.edu as her e-mail for each recommendation request. You need to do this as many times as the number of recommendation letters you are expecting to have.
+c. For each recommendation request, specify under "Document Title" the recommender’s actual name (e.g. Dr. Laurence Ball) and the type of the recommendation letter (generic, academic, non-academic. etc.) per [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation)'s e-mail.
+_For example, if [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) emailed you that Professor Ball wrote you both academic and non-academic letters of recommendation, one of your document titles would be: **Dr. Laurence Ball\_non-academic recommendation** and another would be **Dr. Laurence Ball\_academic recommendation.**_
 d. "Description" - leave blank.
 e. "Message to Recommender" - leave as is.
 f. Under "Recommendation Type" there are two choices - General and Specific position. Only choose **"Specific position"** and enter the recommender actual name along with the type of the reference letter (generic, academic, non-academic. etc...).
 _For example: **Dr. Laurence Ball\_non-academic recommendation**_
-g. "Due date" - this is irrelevant, just choose a date a few days ahead. Your actual deadlines are already included in the spreadsheets sent to [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation).
+g. "Due date" - this is irrelevant, just choose a date a few days ahead. Your actual deadlines are already included in the spreadsheets sent to [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation).
 
-All Interfolio reference letters will be uploaded to Interfolio directly by [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation), including the ones from external recommenders.
+All Interfolio reference letters will be uploaded to Interfolio directly by [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation), including the ones from external recommenders.
 
 ## AcademicJobsOnline - AJO
 
 Instructions for using AcademicJobsOnline:
 
-After all reference letters for each student are received, [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) will make 1 PDF file of all letters and upload their file to the AJO site. The student will be allowed to see when this upload is complete. For example: Prof x - Prof y and Prof z (3 generic ref letters) This service will be provided for JHU Economics Professors and external reference writers.
+After all reference letters for each student are received, [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) will make 1 PDF file of all letters and upload their file to the AJO site. The student will be allowed to see when this upload is complete. For example: Prof x - Prof y and Prof z (3 generic ref letters) This service will be provided for JHU Economics Professors and external reference writers.
 
 ## American Economic Association - AEA
 
 Instructions for using American Economic Association:
 
-Students who are using AEA must inform their JHU Economics Department reference writer to go to [www.aeaweb.org](http://www.econ2.jhu.edu/jobmarket/Information/www.aeaweb.org) and set up a surrogate for their reference letters. The surrogate name is [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation). This service will be provided for JHU Economics professors and external reference writers if they are willing to name [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) as a surrogate.
+Students who are using AEA must inform their JHU Economics Department reference writer to go to [www.aeaweb.org](http://www.econ2.jhu.edu/jobmarket/Information/www.aeaweb.org) and set up a surrogate for their reference letters. The surrogate name is [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation). This service will be provided for JHU Economics professors and external reference writers if they are willing to name [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) as a surrogate.
 
 ## Federal Reserve
 
 Instructions for Federal Reserve:
 
-Students will give [jmstaff.jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) their file naming requirements for their letters which they will obtain directly from the Federal Reserve. For example: 576024\_233025\_JonathanWright.
+Students will give [jmstaff-jhuecon@jhu.edu](https://llorracc.github.io/JobMarket/Notation) their file naming requirements for their letters which they will obtain directly from the Federal Reserve. For example: 576024\_233025\_JonathanWright.
 
 
 ![](http://www.econ2.jhu.edu/images/spacer.gif)

--- a/Templates/CreateLabelandCoverLetterInstruction.md
+++ b/Templates/CreateLabelandCoverLetterInstruction.md
@@ -1,11 +1,10 @@
-# Create Labels
+# Create Cover Letters
+
+Before creating cover letters, your [EmployersMoniker](https://github.com/llorracc/JobMarket/blob/main/Templates/EmployersMoniker.xlsm) file should already be filled according to its instructions.
 
 Depending whether you are using Office 2003, 2007 or 2010, what you see on your screen may be slightly different from the instructions below. The instruction is based on Office 2007.
 
-Before creating labels, your [EmployersMoniker](https://github.com/llorracc/JobMarket/blob/main/Templates/EmployersMoniker.xlsm) file should already be filled according to its instructions.
-
-The template for creating labels for your mass mailing is the [CreateLabels](https://github.com/llorracc/JobMarket/blob/main/Templates/) document in the
-[Templates](https://github.com/llorracc/JobMarket/blob/main/Templates/) directory of the [JobMarket](https://github.com/llorracc/JobMarket) repo.
+The template for creating cover letters for your mass mailing is [CreateCoverLetters](https://github.com/llorracc/JobMarket/blob/main/Templates/) document in [Templates](https://github.com/llorracc/JobMarket/blob/main/Templates/)
 
 When you open your copy of this document, click "Yes" at the pop-up warning window.
 
@@ -15,23 +14,14 @@ When you open your copy of this document, click "Yes" at the pop-up warning wind
 
 <img src="Data-Link-Properties.gif" alt="Data Link Properties&#39;" />
 
-After replacing the directory, click "OK". `CreateLabels` now should be successfully opened.
+After replacing the directory, click "OK". `CreateCoverLetters` now should be successfully opened.
 
-In the **Start Mail Merge** group on the **Mailings** tab, click **Start Mail Merge**, and then click **Step by Step Mail Merge Wizard**.<br />
+In the **Start Mail Merge** group on the **Mailings** tab, click **Step by Step Mail Merge Wizard**.<br />
 <img src="Start%20Mail%20Merge.gif" alt="Start Mail Merge" /><br />
 <br />
-Then, continue clicking **Next Step** until finished.</p></td>
-
-# Create Cover Letters
-
-The template for creating cover letters for your mass mailing is [CreateCoverLetters](https://github.com/llorracc/JobMarket/blob/main/Templates/) document in [Templates](https://github.com/llorracc/JobMarket/blob/main/Templates/)
-
-Follow the same steps as creating labels.
+Then, continue clicking **Next Step** until finished. At the step 3 you can confirm or set (if you did not do it when you opened the document) the path to your target **EmployersMoniker** file. Then, write your letter and add the relevant recipient information (Institution, Position, etc.). Finally, preview your letter, and click **Edit individual letters** if you want to further personalize some letters. </p></td>
 
 <tr class="odd">
 <td><h3 id="personalization">Personalization</h3>
 If you want to further improve the appearance of your labels and cover letters, further reference can be found at <a href="http://office.microsoft.com/en-us/word-help/create-and-print-labels-for-a-mass-mailing-HA010109161.aspx">http://office.microsoft.com/en-us/word-help/create-and-print-labels-for-a-mass-mailing-HA010109161.aspx</a></td>
 </tr>
-
-
-


### PR DESCRIPTION
From jmstaff.jhuecon@jhu.edu (point) to jmstaff-jhuecon@jhu.edu (hyphen)